### PR TITLE
Updating package-lock.json file to upgrade some dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ubidots-nodered",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,9 +139,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ubidots-nodered",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "NodeRED node to post data on Ubidots using MQTT.",
   "node-red": {
     "nodes": {


### PR DESCRIPTION
There's a low severity vulnerability in the current version of the `extend` package that is present in the package-lock.json on this repository.

The vulnerability in specific is prototype pollution and you can read a bit more about it here: https://nvd.nist.gov/vuln/detail/CVE-2018-16492

As `help-me` which is the dependency that depends (yeah 😅) on `extends` has configured it to install the most recent major version, I just had to update the version that was present on the lock without any issues.